### PR TITLE
Update revalidation handler to respond to semester/course sanity updates

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -13,6 +13,11 @@ if (SECRET === "") {
 type SanityWebhookPayload = {
   _type: "review";
   course: Pick<Course, "slug">;
+} | {
+  _type: "course";
+  slug: Course["slug"];
+} | {
+  _type: "semester";
 };
 
 export async function POST(req: Request) {
@@ -30,9 +35,24 @@ export async function POST(req: Request) {
 
   const payload = JSON.parse(body) as SanityWebhookPayload;
 
-  revalidatePath(`/courses/${payload.course.slug}/reviews`);
-  revalidatePath("/reviews/recent");
-  revalidatePath("/");
+  if(payload._type === 'review') {
+    revalidatePath(`/courses/${payload.course.slug}/reviews`);
+    revalidatePath("/reviews/recent");
+    revalidatePath("/");
+  }
+  
+  if(payload._type === 'course') {
+    revalidatePath(`/courses/${payload.slug}/reviews`);
+    revalidatePath("/reviews/new");
+    revalidatePath("/");
+  }
+
+  if(payload._type === 'semester') {
+    revalidatePath("/reviews/new");
+  }
+
 
   NextResponse.json({}, { status: 200 });
 }
+
+


### PR DESCRIPTION
We want to regenerate pages on demand when the underlying data changes. This PR adds revalidation logic in response to notifications about course/semester additions/updates/deletions.

When we modify a course, we want to regenerate:
- The reviews page for the course
- The new review form (to populate the course dropdown, though maybe this should be an API call)
- The homepage

When we modify a semester, we want to regenerate:
- The new review form (to populate the semester radio group, though maybe this too should be an API call)

The associated webhooks are defined [here](https://www.sanity.io/organizations/oohHvLNHA/project/3yw11hu2/api/webhooks), and screenshots are provided below.

<img width="993" height="698" alt="image" src="https://github.com/user-attachments/assets/621d31d2-d52a-4b33-a46b-217e36d53ba3" />

They will be enabled after this branch is merged.