### PR TITLE
Show all courses on homepage by default.

### DIFF
--- a/src/app/home-page.tsx
+++ b/src/app/home-page.tsx
@@ -226,8 +226,7 @@ export default function Home({ courses }: HomePageProps): JSX.Element {
   const [view, setView] = useState<CourseWithStats[]>([]);
 
   // FILTERING
-  // By default only show courses with 1+ review
-  const [minReviewCount, setMinReviewCount] = useState<number>(1);
+  const [minReviewCount, setMinReviewCount] = useState<number>();
   const [maxReviewCount, setMaxReviewCount] = useState<number>();
 
   const [minRating, setMinRating] = useState<number>();
@@ -256,7 +255,7 @@ export default function Home({ courses }: HomePageProps): JSX.Element {
           reviewCount,
         }) =>
           between(
-            reviewCount,
+            reviewCount || 0,
             minReviewCount || 0,
             maxReviewCount || Number.POSITIVE_INFINITY,
           ) &&
@@ -437,7 +436,7 @@ export default function Home({ courses }: HomePageProps): JSX.Element {
                                       id="minReview"
                                       type="text"
                                       label="Min Reviews"
-                                      placeholder="1"
+                                      placeholder="0"
                                       defaultValue={getDefaultInputValue(
                                         minReviewCount,
                                       )}


### PR DESCRIPTION
Previously, a default value of one was set on the min review input field in the (initially) hidden course filter form on the homepage. It took me 30 minutes of debugging to figure out why I couldn't see new courses before I finally saw that input value. If it's confusing to me, I'm sure it's confusing to others.

<img width="1233" height="731" alt="image" src="https://github.com/user-attachments/assets/773f7630-f361-4ea2-844b-a6e73ead72aa" />