### PR TITLE
Fix to allow added courses post-deploy to render on first request

### DIFF
--- a/src/app/courses/[slug]/reviews/page.tsx
+++ b/src/app/courses/[slug]/reviews/page.tsx
@@ -8,6 +8,7 @@ import { PlusIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import { Metadata } from "next";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
 import { Review } from "src/components/review";
 import { sanityClient } from "src/sanity/client";
@@ -27,7 +28,9 @@ export async function generateStaticParams() {
   return await sanityClient.fetch(COURSE_SLUGS_QUERY);
 }
 
-export const dynamicParams = false;
+// Allow courses added after the last deploy to render on first request.
+// Unknown slugs still 404 via notFound() below.
+export const dynamicParams = true;
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
@@ -45,13 +48,18 @@ export default async function Page({ params }: Props) {
   const { slug } = await params;
 
   const course = await sanityClient.fetch(COURSE_WITH_REVIEWS_QUERY, { slug });
-  const reviews = course?.reviews ?? [];
+
+  if (course === null) {
+    notFound();
+  }
+
+  const reviews = course.reviews ?? [];
 
   const rating = average(reviews, "rating");
   const difficulty = average(reviews, "difficulty");
   const workload = average(reviews, "workload");
 
-  const programAcronyms = course?.programs?.reduce<string[]>(
+  const programAcronyms = course.programs?.reduce<string[]>(
     (acc, { acronym }) => (acronym === null ? acc : [...acc, acronym]),
     [],
   );


### PR DESCRIPTION
### Problem
Course review pages use `generateStaticParams` plus `dynamicParams = false` added in [PR #183](https://github.com/oms-fyi/reviews/pull/183) so only slugs known at build time are allowed. 

This means that courses created in Studiuo after the last deploy are never in the list, so a recently added course like `/courses/power-system-control-and-operation/reviews` returns 404. 

### Solution
Updated reviews page to:
1. Set `dynamicParams = true` so post-deploy courses render on first request
2. Call `notFound()` when the slug isn't in Sanity (so junk URLs still 404)

Validated newly added course shows up post build locally. 
<img width="1455" height="522" alt="image" src="https://github.com/user-attachments/assets/cdefd21c-9ed0-4b66-8bea-a2602515ca1a" />
