### PR TITLE
Replace default Next.js site description with OMSCentral copy.

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,8 +18,9 @@ const inter = Inter({
 
 export function generateMetadata(): Metadata {
   return {
-    title: "Home",
-    description: "Welcome to Next.js",
+    title: "OMSCentral",
+    description:
+      "Course reviews, ratings, difficulty, and workload for Georgia Tech OMS programs.",
     other: {
       ...Sentry.getTraceData(),
     },


### PR DESCRIPTION
Link previews were showing the starter template text from root metadata.

<img width="271" height="107" alt="image" src="https://github.com/user-attachments/assets/029eacb4-05da-4ac9-b64c-faedfc38c095" />
