### PR TITLE
Replace heroicons with lucide-icons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Project conventions
+
+## Icon imports
+
+Always import icons using their `Icon`-suffixed name (e.g. `SearchIcon`, not `Search`). This repo uses `lucide-react`, which exports both a bare name and an `Icon`-suffixed alias for every icon (e.g. `Search`/`SearchIcon`, `X`/`XIcon`) — always import the `Icon`-suffixed one.
+
+Why: bare names like `Search`, `Menu`, `X`, or `Info` collide with common variable/component names and other libraries (e.g. Headless UI's `Menu`), and are harder to grep for or recognize at a glance as icons.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@headlessui/react": "^2.2.9",
-    "@heroicons/react": "^2.2.0",
     "@sanity/client": "^7.13.2",
     "@sanity/icons": "^3.7.4",
     "@sanity/image-url": "^1.2.0",
@@ -27,6 +26,7 @@
     "fuse.js": "^7.1.0",
     "groq": "^5.1.0",
     "joi": "^18.0.2",
+    "lucide-react": "^1.26.0",
     "next": "16.1.1",
     "next-sanity": "^11.6.12",
     "react": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@headlessui/react':
         specifier: ^2.2.9
         version: 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@heroicons/react':
-        specifier: ^2.2.0
-        version: 2.2.0(react@19.2.3)
       '@sanity/client':
         specifier: ^7.13.2
         version: 7.13.2(debug@4.4.3)
@@ -50,6 +47,9 @@ importers:
       joi:
         specifier: ^18.0.2
         version: 18.0.2
+      lucide-react:
+        specifier: ^1.26.0
+        version: 1.26.0(react@19.2.3)
       next:
         specifier: 16.1.1
         version: 16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1113,11 +1113,6 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
-
-  '@heroicons/react@2.2.0':
-    resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
-    peerDependencies:
-      react: '>= 16 || ^19.0.0-rc'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -5238,6 +5233,11 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lucide-react@1.26.0:
+    resolution: {integrity: sha512-raglYVR2+VkMfJL158krjVmE+rV5ST2lzA/KQm1FRSjMHT4MnWaegHxoVEpmc2So3nOEhp9oGejJwAPX8MoAjg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -8449,10 +8449,6 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       use-sync-external-store: 1.6.0(react@19.2.3)
-
-  '@heroicons/react@2.2.0(react@19.2.3)':
-    dependencies:
-      react: 19.2.3
 
   '@humanfs/core@0.19.1': {}
 
@@ -13079,6 +13075,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@1.26.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   magic-string@0.30.21:
     dependencies:

--- a/src/app/courses/[slug]/reviews/page.tsx
+++ b/src/app/courses/[slug]/reviews/page.tsx
@@ -1,11 +1,11 @@
-import {
-  BoltIcon,
-  ClockIcon,
-  DocumentPlusIcon,
-  StarIcon,
-} from "@heroicons/react/24/outline";
-import { PlusIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
+import {
+  ClockIcon,
+  FilePlusIcon,
+  PlusIcon,
+  StarIcon,
+  ZapIcon,
+} from "lucide-react";
 import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -76,7 +76,7 @@ export default async function Page({ params }: Props) {
             {formatNumber(rating)} / 5 rating
           </span>
           <span className="flex items-center gap-0 lg:gap-1">
-            <BoltIcon className="h-5 w-5 stroke-indigo-600 dark:stroke-indigo-300" />
+            <ZapIcon className="h-5 w-5 stroke-indigo-600 dark:stroke-indigo-300" />
             {formatNumber(difficulty)} / 5 difficulty
           </span>
           <span className="flex items-center gap-0 lg:gap-1">
@@ -224,7 +224,7 @@ export default async function Page({ params }: Props) {
           <div className="w-full max-w-xl grow bg-white px-4 py-2 shadow-sm sm:rounded-lg lg:max-w-full dark:bg-gray-900 dark:ring-1 dark:ring-white/10">
             <div className="px-4 py-5 sm:p-6">
               <div className="text-center">
-                <DocumentPlusIcon className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-300" />
+                <FilePlusIcon className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-300" />
                 <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
                   No reviews
                 </h3>

--- a/src/app/home-page.tsx
+++ b/src/app/home-page.tsx
@@ -1,20 +1,18 @@
 "use client";
 
 import { Listbox, Popover, Transition } from "@headlessui/react";
-import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-  FunnelIcon,
-  InformationCircleIcon,
-  MagnifyingGlassIcon,
-} from "@heroicons/react/24/outline";
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  ChevronUpDownIcon,
-} from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import Fuse from "fuse.js";
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronUpIcon,
+  ChevronsUpDownIcon,
+  FunnelIcon,
+  InfoIcon,
+  SearchIcon,
+} from "lucide-react";
 import Link from "next/link";
 import { FC, Fragment, type JSX, useEffect, useMemo, useState } from "react";
 
@@ -382,7 +380,7 @@ export default function Home({ courses }: HomePageProps): JSX.Element {
                 <div className="mt-1 flex rounded-md shadow-xs">
                   <div className="relative flex grow items-stretch focus-within:z-10">
                     <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                      <MagnifyingGlassIcon
+                      <SearchIcon
                         className="hidden h-5 w-5 text-gray-400 sm:block"
                         aria-hidden="true"
                       />
@@ -661,7 +659,7 @@ export default function Home({ courses }: HomePageProps): JSX.Element {
                           )}
                         </div>
                         <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                          <ChevronUpDownIcon
+                          <ChevronsUpDownIcon
                             className="h-5 w-5 text-gray-400"
                             aria-hidden="true"
                           />
@@ -739,7 +737,7 @@ export default function Home({ courses }: HomePageProps): JSX.Element {
                         <Popover className="relative">
                           <>
                             <Popover.Button type="button">
-                              <InformationCircleIcon className="h-4 w-4 text-indigo-600 dark:text-indigo-300" />
+                              <InfoIcon className="h-4 w-4 text-indigo-600 dark:text-indigo-300" />
                             </Popover.Button>
                             <Transition
                               as={Fragment}

--- a/src/app/reviews/new/new-page.tsx
+++ b/src/app/reviews/new/new-page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Combobox, Dialog, Transition } from "@headlessui/react";
-import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
+import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
 import Link from "next/link";
 import { FormEvent, Fragment, useEffect, useMemo, useState } from "react";
 
@@ -224,7 +224,7 @@ export default function NewReviewForm({
                   displayValue={() => selectedCourse?.name ?? ""}
                 />
                 <Combobox.Button className="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
-                  <ChevronUpDownIcon
+                  <ChevronsUpDownIcon
                     className="h-5 w-5 text-gray-400"
                     aria-hidden="true"
                   />

--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -1,9 +1,5 @@
-import {
-  CheckCircleIcon,
-  XCircleIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/solid";
 import classNames from "classnames";
+import { CircleCheckIcon, CircleXIcon, XIcon } from "lucide-react";
 import type { JSX } from "react";
 
 interface AlertProps {
@@ -30,9 +26,9 @@ export function Alert({
       <div className="flex">
         <div className="shrink-0">
           {variant === "success" ? (
-            <CheckCircleIcon className="h-5 w-5 text-green-400" />
+            <CircleCheckIcon className="h-5 w-5 text-green-400" />
           ) : (
-            <XCircleIcon className="h-5 w-5 text-red-400" />
+            <CircleXIcon className="h-5 w-5 text-red-400" />
           )}
         </div>
         <div
@@ -62,7 +58,7 @@ export function Alert({
               )}
             >
               <span className="sr-only">Dismiss</span>
-              <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+              <XIcon className="h-5 w-5" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,18 +1,18 @@
 "use client";
 
 import { Disclosure, Menu, Transition } from "@headlessui/react";
-import { PlusIcon } from "@heroicons/react/20/solid";
+import classNames from "classnames";
 import {
-  Bars3Icon,
   ChevronDownIcon,
   ClockIcon,
-  CpuChipIcon,
-  CurrencyDollarIcon,
-  GlobeAltIcon,
-  LockClosedIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline";
-import classNames from "classnames";
+  CpuIcon,
+  DollarSignIcon,
+  GlobeIcon,
+  LockIcon,
+  MenuIcon,
+  PlusIcon,
+  XIcon,
+} from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
@@ -31,25 +31,25 @@ const reviewsMenuItems = [
     title: "CS-6250",
     subtitle: "Computer Networks",
     href: "/courses/computer-networks/reviews",
-    icon: GlobeAltIcon,
+    icon: GlobeIcon,
   },
   {
     title: "CS-6035",
     subtitle: "Introduction to Information Security",
     href: "/courses/introduction-to-information-security/reviews",
-    icon: LockClosedIcon,
+    icon: LockIcon,
   },
   {
     title: "CS-7646",
     subtitle: "Machine Learning for Trading",
     href: "/courses/machine-learning-for-trading/reviews",
-    icon: CurrencyDollarIcon,
+    icon: DollarSignIcon,
   },
   {
     title: "CS-6200",
     subtitle: "Introduction to Operating Systems",
     href: "/courses/graduate-introduction-to-operating-systems/reviews",
-    icon: CpuChipIcon,
+    icon: CpuIcon,
   },
 ];
 
@@ -95,7 +95,10 @@ export function Header(): JSX.Element {
   }, [params.slug]);
 
   return (
-    <Disclosure as="nav" className="bg-white shadow-sm dark:border-b dark:border-gray-800 dark:bg-gray-900 dark:shadow-none">
+    <Disclosure
+      as="nav"
+      className="bg-white shadow-sm dark:border-b dark:border-gray-800 dark:bg-gray-900 dark:shadow-none"
+    >
       {({ open }) => (
         <>
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -106,9 +109,9 @@ export function Header(): JSX.Element {
                   <Disclosure.Button className="inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:ring-2 focus:ring-indigo-500 focus:outline-hidden focus:ring-inset dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100">
                     <span className="sr-only">Open main menu</span>
                     {open ? (
-                      <XMarkIcon className="block h-6 w-6" aria-hidden="true" />
+                      <XIcon className="block h-6 w-6" aria-hidden="true" />
                     ) : (
-                      <Bars3Icon className="block h-6 w-6" aria-hidden="true" />
+                      <MenuIcon className="block h-6 w-6" aria-hidden="true" />
                     )}
                   </Disclosure.Button>
                 </div>

--- a/src/components/review.tsx
+++ b/src/components/review.tsx
@@ -1,9 +1,5 @@
-import {
-  CalendarIcon,
-  PencilSquareIcon,
-  UserCircleIcon,
-} from "@heroicons/react/24/outline";
 import classNames from "classnames";
+import { CalendarIcon, CircleUserRoundIcon, SquarePenIcon } from "lucide-react";
 import Link from "next/link";
 import { type JSX } from "react";
 import ReactMarkdown from "react-markdown";
@@ -41,14 +37,14 @@ export function Review({
   return (
     <article className="prose prose-sm dark:prose-invert mx-auto bg-white px-6 py-3 shadow-sm sm:rounded-lg dark:bg-gray-900 dark:ring-1 dark:ring-white/10">
       <p className="flex items-center gap-2">
-        <UserCircleIcon className="h-11 w-11 text-gray-400 dark:text-gray-300" />
+        <CircleUserRoundIcon className="h-11 w-11 text-gray-400 dark:text-gray-300" />
         <span className="flex flex-col gap-1">
           <span className="font-medium">
             {author ?? "Georgia Tech Student"}
           </span>
           <span className="flex gap-3">
             <span className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-300">
-              <PencilSquareIcon className="h-4 w-4" aria-hidden="true" />
+              <SquarePenIcon className="h-4 w-4" aria-hidden="true" />
               <Time dateTime={createdAt} opts={{ dateStyle: "long" }} />
             </span>
             <span className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-300">

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  ComputerDesktopIcon,
-  MoonIcon,
-  SunIcon,
-} from "@heroicons/react/24/outline";
+import { MonitorIcon, MoonIcon, SunIcon } from "lucide-react";
 import { type JSX, useEffect, useState } from "react";
 
 const THEME_PREFERENCES = ["light", "dark", "system"] as const;
@@ -19,7 +15,7 @@ const THEME_TO_NEXT_THEME: Record<ThemePreference, ThemePreference> = {
 const THEME_ICONS = {
   light: SunIcon,
   dark: MoonIcon,
-  system: ComputerDesktopIcon,
+  system: MonitorIcon,
 } as const;
 
 function isThemePreference(value: string | null): value is ThemePreference {


### PR DESCRIPTION
## Summary
- Swaps `@heroicons/react` for `lucide-react` across all 7 files that used icons (alert, header, theme-toggle, review, home page, course reviews page, new review form)
- Imports every icon by its `Icon`-suffixed export (e.g. `SearchIcon`, not `Search`) since lucide-react ships both forms natively — avoids collisions with non-icon names like Headless UI's `Menu`
- Documents the icon-import convention in `CLAUDE.md`
- Removes the `@heroicons/react` dependency

Closes #201

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` shows no new issues (same pre-existing baseline as `main`)
- [x] `pnpm build` compiles successfully
- [x] Verified in the running dev server that icons render correctly on the home page, course reviews page, and new-review form, with no leftover heroicons references